### PR TITLE
Pika API update

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ If you need more information about that docker image: https://hub.docker.com/_/r
 
 ## Changelog
 
+### v0.8.1
+
+* use latest version of all external libraries (no specific version requirement)
+* pika API changed again, cottontail now support the latest calling convention
+
 ### v0.8.0
 
 * fix issue when requeuing (see [#22](https://github.com/QKaiser/cottontail/issues/22) and [#23](https://github.com/QKaiser/cottontail/issues/23))

--- a/bin/cottontail
+++ b/bin/cottontail
@@ -54,8 +54,9 @@ def subproc(host, port, ssl, username, password, vhost_name):
     logger.verbose("Connecting to amqp{}://{}:{}/{}".format(
         "s" if ssl else "", host, port, vhost_name))
 
-    ssl_options = {}
+    ssl_options = None
     if ssl:
+        ssl_options = {}
         import ssl as s
         ssl_options["cert_reqs"] = s.CERT_NONE
 
@@ -63,7 +64,7 @@ def subproc(host, port, ssl, username, password, vhost_name):
         credentials = pika.PlainCredentials(username, password)
         parameters = pika.ConnectionParameters(
             host=host, port=port, virtual_host=vhost_name,
-            credentials=credentials, ssl=ssl, ssl_options=ssl_options)
+            credentials=credentials, ssl_options=ssl_options)
         connection = pika.BlockingConnection(parameters)
         channel = connection.channel()
 
@@ -224,7 +225,7 @@ def subproc(host, port, ssl, username, password, vhost_name):
                 for routing_key in routing_keys:
                     # declaration is passive so we don't need to check the
                     # 'configure' permission
-                    result = channel.queue_declare(exclusive=True)
+                    result = channel.queue_declare(exclusive=True, queue='')
                     queue_name = result.method.queue
                     logger.info(
                         "Binding queue [vhost={}][exchange={}][queue={}]"\
@@ -244,7 +245,7 @@ def subproc(host, port, ssl, username, password, vhost_name):
                     )
                     # we checked 'read' permission on auto-generated queue
                     # name format
-                    channel.basic_consume(callback, queue=queue_name, no_ack=True)
+                    channel.basic_consume(on_message_callback=callback, queue=queue_name, auto_ack=False)
 
         logger.warning(
             "[{}] Waiting for messages. To exit press CTRL+C".format(vhost_name)

--- a/cottontail/__init__.py
+++ b/cottontail/__init__.py
@@ -1,3 +1,3 @@
 __author__  = "Quentin Kaiser"
 __email__   = "kaiserquentin@gmail.com"
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coloredlogs==7.3
-pika==0.10.0
-requests>=2.20.0
-urllib3>=1.23
-verboselogs==1.7
+pika
+requests
+urllib3
+verboselogs

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
     license                 = 'BSD-3',
     zip_safe                = False,
     install_requires        = [ 'coloredlogs', 'verboselogs', 'pika',\
-        'requests==2.21.0', 'urllib3==1.21.1' ]
+        'requests', 'urllib3' ]
 )


### PR DESCRIPTION
Use latest version of all external libraries. Pika API changed again, cottontail now support the latest calling convention.